### PR TITLE
Bump xmos_cmake_toolchain to v1.0.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@ lib_qspi_fast_read change log
 -----
 
     * CHANGED: Documentation built under xmosdoc
+    * CHANGED: Update xmos_cmake_toolchain to v1.0.0 from untagged commit
+               3a19f0284c66a92dbb9d5adc9d3d5016aac22646
 
 1.0.1
 -----


### PR DESCRIPTION
[AP-237](https://xmosjira.atlassian.net/browse/AP-237)

[AP-237]: https://xmosjira.atlassian.net/browse/AP-237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ